### PR TITLE
Fix transition syntax in Notification component

### DIFF
--- a/src/Notification.svelte
+++ b/src/Notification.svelte
@@ -6,7 +6,7 @@
 </script>
 
 {#if show}
-  <p in:fly="{{ y: -200, duration: 1000}}" out:fade>{text}</p>
+  <p in:fly={{ y: -200, duration: 1000 }} out:fade>{text}</p>
 {/if}
 
 <style>


### PR DESCRIPTION
## Summary
- remove stray quotes from Notification fly transition

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851dfd6ba1c8323acb3fd40384f3fe0